### PR TITLE
fix(enterprise): don't require rollbar token for enterprise

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -7,15 +7,20 @@ const urlArray = envalid.makeValidator(x => {
   return urls.map(url()._parse).filter(Boolean)
 })
 
-module.exports = envalid.cleanEnv(process.env, {
+const environmentConfig = {
   AMQP_URL: url({devDefault: 'amqp://localhost'}),
   REGISTRY_URLS: urlArray({default: '["https://replicate.npmjs.com/registry"]'}),
   REDIS_URL: url({default: 'redis://redis:6379', devDefault: 'redis://localhost:6379'}),
   REDIS_SEQ_KEY: str({default: 'changes-seq'}),
   QUEUE_NAME: str({default: 'events'}),
   NODE_ENV: str({choices: ['development', 'staging', 'production'], devDefault: 'development'}),
-  ROLLBAR_TOKEN_CHANGES: str({devDefault: ''}),
   STATSD_HOST: str({default: '172.17.0.1'}),
   REGISTRY_CHANGE_DELAY: num({default: 1000 * 60, devDefault: 1000}),
   IS_ENTERPRISE: bool({default: false})
-})
+}
+
+if (!process.env.IS_ENTERPRISE) {
+  environmentConfig.ROLLBAR_TOKEN_CHANGES = str({devDefault: ''})
+}
+
+module.exports = envalid.cleanEnv(process.env, environmentConfig)


### PR DESCRIPTION
Startup will fail if rollbar token is not set.

Alternative would be to provide it with a default, but then this would also happen for SaaS, where we want things to fail if no token was provided.