### PR TITLE
fix: properly filter empty URLs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,8 @@
 const amqp = require('amqplib')
 const redis = require('redis')
-const isEmpty = require('lodash').isEmpty
 
 const env = require('./lib/env')
 const {parseRegistryUrl, checkFollower, startChanges} = require('./lib/follow')
-const isNotEmpty = (value) => !isEmpty(value)
 
 ;(async () => {
   const conn = await amqp.connect(env.AMQP_URL)
@@ -14,7 +12,7 @@ const isNotEmpty = (value) => !isEmpty(value)
   })
   const client = redis.createClient(env.REDIS_URL)
 
-  env.REGISTRY_URLS.filter(isNotEmpty).forEach(registryUrl => {
+  env.REGISTRY_URLS.forEach(registryUrl => {
     const registry = parseRegistryUrl(registryUrl)
     const start = startChanges.bind(null, {
       channel,

--- a/lib/env.js
+++ b/lib/env.js
@@ -1,10 +1,13 @@
 const envalid = require('envalid')
+const isEmpty = require('lodash').isEmpty
 const {str, url, json, bool, num} = envalid
+
+const isNotEmpty = (value) => !isEmpty(value)
 
 const urlArray = envalid.makeValidator(x => {
   const urls = json()._parse(x)
   if (!Array.isArray(urls)) throw new Error('JSON is no array')
-  return urls.map(url()._parse).filter(Boolean)
+  return urls.filter(isNotEmpty).map(url()._parse)
 })
 
 const environmentConfig = {


### PR DESCRIPTION
With the previous change, the `url.parse()` from envalid stumbled over the empty URL before we even could filter it out.

`.filter(Boolean)` is a shortcut to remove values that resolve to falsey, but since we already filter out empty values, we don't need it any longer and it also came to late in the chain anyway, as the URL parser craps out earlier.